### PR TITLE
[add]project 페이지 완성

### DIFF
--- a/src/app/company-project/page.tsx
+++ b/src/app/company-project/page.tsx
@@ -1,7 +1,6 @@
 import { Project } from "@/types/project";
 import Backbutton from "@/components/buttons/Backbutton";
-import ProjectList from "@/components/projects/ProjectList";
-import ProjectModal from "@/components/ProjectModal";
+import ProjectsView from "@/components/projects/ProjectsView";
 
 async function getProjects(): Promise<Project[]> {
   try {
@@ -34,10 +33,7 @@ export default async function Page() {
         {projects.length === 0 ? (
           <div className="text-center text-gray-500 dark:text-gray-400">프로젝트가 없습니다.</div>
         ) : (
-          <>
-            <ProjectList projects={projects} />
-            {/* <ProjectModal project={}, isOpen={}, onClose={} /> */}
-          </>
+          <ProjectsView projects={projects} />
         )}
       </main>
     </div>

--- a/src/app/project/page.tsx
+++ b/src/app/project/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import Image from "next/image";
+import Backbutton from "@/components/buttons/Backbutton";
 
 // 프로젝트 데이터 타입 정의
 type Project = {
@@ -11,88 +11,85 @@ type Project = {
   githubUrl?: string;
   demoUrl?: string;
   imageUrl: string;
+  media?: { media_type: string; media_url: string }[];
 };
 
-// 프로젝트 데이터
-const projects: Project[] = [
-  {
-    id: 1,
-    title: "개인 프로젝트 1",
-    description: "개인 프로젝트 1에 대한 상세 설명입니다. 주요 기능과 성과를 기술합니다.",
-    period: "2023.01 - 2023.03",
-    techStack: ["React", "TypeScript", "Firebase"],
-    githubUrl: "https://github.com/yourusername/project1",
-    demoUrl: "https://project1-demo.com",
-    imageUrl: "/personal-project1.jpg",
-  },
-  {
-    id: 2,
-    title: "개인 프로젝트 2",
-    description: "개인 프로젝트 2에 대한 상세 설명입니다. 주요 기능과 성과를 기술합니다.",
-    period: "2023.04 - 2023.06",
-    techStack: ["Next.js", "MongoDB", "Tailwind CSS"],
-    githubUrl: "https://github.com/yourusername/project2",
-    imageUrl: "/personal-project2.jpg",
-  },
-];
-
 async function GetProjects(): Promise<Project[]> {
-  // const res = await fetch(`${process.env.NEXT_PUBLIC_NODE_DOMAIN}/api/projcet`);
+  const res = await fetch(`${process.env.NEXT_PUBLIC_INTERNAL_DOMAIN}/api/projects/individual`);
 
-  // if (!res.ok) {
-  //   throw new Error("프로젝트를 불러오지 못하였습니다.");
-  // }
+  if (!res.ok) {
+    throw new Error("프로젝트를 불러오지 못하였습니다.");
+  }
 
-  return projects;
+  return res.json();
 }
 
-export default function Project() {
-  // const project = await GetProjects();
+export default async function Project() {
+  const projects = await GetProjects();
+  console.log(projects);
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-gray-50 to-white dark:from-gray-900 dark:to-gray-800">
       <main className="max-w-4xl mx-auto px-4 py-12">
         <div className="mb-8">
-          <Link
-            href="/"
-            className="inline-flex items-center text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
-          >
-            <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-            </svg>
-            홈으로 돌아가기
-          </Link>
+          <Backbutton href="/">홈으로 돌아가기</Backbutton>
         </div>
 
         <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-8">개인 프로젝트</h1>
 
         <div className="space-y-12">
-          {projects.map((project) => (
+          {projects?.map((project) => (
             <div
-              key={project.id}
+              key={`personal-${project?.id}`}
               className="bg-white dark:bg-gray-800 rounded-lg shadow-sm overflow-hidden border border-gray-200 dark:border-gray-700"
             >
-              <div className="relative h-64">
-                <Image src={project.imageUrl} alt={project.title} fill className="object-cover" />
+              <div className="flex overflow-x-auto gap-4 snap-x pb-2 h-fit">
+                {[
+                  ...(project?.media?.filter((m) => m.media_type === "video") || []),
+                  ...(project?.media?.filter((m) => m.media_type === "image") || []),
+                ]?.map((media, index) => (
+                  <div key={index} className="flex-shrink-0 w-full max-h-150 relative snap-center">
+                    {media?.media_type === "image" ? (
+                      <Image
+                        src={media?.media_url}
+                        alt={`${project?.title} image ${index}`}
+                        className="w-full h-full object-contain rounded-lg"
+                        width={0}
+                        height={0}
+                        sizes="100vw"
+                      />
+                    ) : media?.media_type === "video" ? (
+                      media?.media_url.includes("youtube.com") ? (
+                        <iframe
+                          className="w-full h-full rounded-lg"
+                          src={media?.media_url.replace("/shorts/", "/embed/")}
+                          allowFullScreen
+                        />
+                      ) : (
+                        <video src={media?.media_url} controls className="w-full h-full object-cover rounded-lg" />
+                      )
+                    ) : null}
+                  </div>
+                ))}
               </div>
               <div className="p-6">
-                <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-2">{project.title}</h2>
-                <p className="text-gray-600 dark:text-gray-300 mb-4">{project.period}</p>
-                <p className="text-gray-600 dark:text-gray-300 mb-6">{project.description}</p>
+                <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-2">{project?.title}</h2>
+                <p className="text-gray-600 dark:text-gray-300 mb-4">{project?.period}</p>
+                <p className="text-gray-600 dark:text-gray-300 mb-6">{project?.description}</p>
                 <div className="flex flex-wrap gap-2 mb-6">
-                  {project.techStack.map((tech, index) => (
+                  {project?.techStack?.map((tech, index) => (
                     <span
                       key={index}
                       className="px-3 py-1 bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 rounded-full text-sm"
                     >
-                      {tech}
+                      {tech?.name}
                     </span>
                   ))}
                 </div>
                 <div className="flex gap-4">
-                  {project.githubUrl && (
+                  {project?.link && (
                     <a
-                      href={project.githubUrl}
+                      href={project?.link}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="inline-flex items-center px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800"
@@ -105,24 +102,6 @@ export default function Project() {
                         />
                       </svg>
                       GitHub
-                    </a>
-                  )}
-                  {project.demoUrl && (
-                    <a
-                      href={project.demoUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
-                    >
-                      <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                        />
-                      </svg>
-                      데모 보기
                     </a>
                   )}
                 </div>

--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { ProjectModalProps } from "@/types/project";
 import Image from "next/image";
 import { useEffect, useRef } from "react";
@@ -40,7 +41,7 @@ export default function ProjectModal({ project, isOpen, onClose }: ProjectModalP
       >
         <div className="p-6">
           <div className="flex justify-between items-start mb-6">
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">{project.title}</h2>
+            <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">{project?.title}</h2>
             <button
               onClick={onClose}
               className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
@@ -51,9 +52,24 @@ export default function ProjectModal({ project, isOpen, onClose }: ProjectModalP
             </button>
           </div>
 
-          <div className="relative h-64 mb-6">
-            {project.imageUrl ? (
-              <Image src={project.imageUrl} alt={project.title} fill className="object-cover rounded-lg" />
+          <div className="relative h-fit mb-6">
+            {project?.media ? (
+              <div className="flex overflow-x-auto gap-4 snap-x pb-2">
+                {project?.media?.map((media, index) => (
+                  <div key={index} className="flex-shrink-0 w-full h-100 relative snap-center">
+                    {media.media_type === "image" ? (
+                      <Image
+                        src={media.media_url}
+                        alt={`project-media-${index}`}
+                        fill
+                        className="h-full object-contain rounded-lg"
+                      />
+                    ) : media.media_type === "video" ? (
+                      <video src={media.media_url} controls className="w-full h-full object-cover rounded-lg" />
+                    ) : null}
+                  </div>
+                ))}
+              </div>
             ) : (
               <div className="w-full h-full bg-gray-200 dark:bg-gray-700 rounded-lg flex items-center justify-center">
                 <span className="text-gray-500 dark:text-gray-400">이미지 없음</span>
@@ -63,34 +79,35 @@ export default function ProjectModal({ project, isOpen, onClose }: ProjectModalP
 
           <div className="space-y-4">
             <div className="flex items-center text-gray-600 dark:text-gray-300">
-              <span className="mr-4">{project.period}</span>
-              <span>{project.role}</span>
+              <span className="mr-4">{project?.period}</span>
+              {project?.period && project?.role && <span className="mr-4">|</span>}
+              <span>{project?.role}</span>
             </div>
 
             <div className="flex flex-wrap gap-2">
-              {project.techStack.map((tech, index) => (
+              {project?.techStack?.map((tech, index) => (
                 <span
                   key={index}
                   className="px-3 py-1 bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 rounded-full text-sm"
                 >
-                  {tech}
+                  {tech?.name}
                 </span>
               ))}
             </div>
 
-            <p className="text-gray-600 dark:text-gray-300">{project.description}</p>
+            <p className="text-gray-600 dark:text-gray-300">{project?.description}</p>
 
-            {project.content && (
+            {project?.content && (
               <div className="mt-4">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">상세 내용</h3>
-                <p className="text-gray-600 dark:text-gray-300 whitespace-pre-line">{project.content}</p>
+                <p className="text-gray-600 dark:text-gray-300 whitespace-pre-line">{project?.content}</p>
               </div>
             )}
 
-            {project.link && (
+            {project?.link && (
               <div className="mt-6">
                 <a
-                  href={project.link}
+                  href={project?.link}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"

--- a/src/components/projects/ProjectList.tsx
+++ b/src/components/projects/ProjectList.tsx
@@ -1,13 +1,19 @@
+"use client";
+
 import Image from "next/image";
 import { Project } from "@/types/project";
+import useProjectModal from "@/store";
 
 export default function ProjectList({ projects }: { projects: Project[] }) {
+  const { onOpen } = useProjectModal();
+
   return (
     <div className="space-y-4">
-      {projects.map((project) => (
+      {projects?.map((project) => (
         <div
           key={project.id}
           className="bg-white dark:bg-gray-800 rounded-lg shadow-sm overflow-hidden border border-gray-200 dark:border-gray-700"
+          onClick={() => onOpen(project)}
         >
           <div className="flex flex-col md:flex-row items-center p-4 gap-4">
             <div className="flex flex-row md:flex-col gap-2 w-full md:w-32 md:h-32 justify-center items-center">

--- a/src/components/projects/ProjectsView.tsx
+++ b/src/components/projects/ProjectsView.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import React from "react";
+import ProjectList from "@/components/projects/ProjectList";
+import ProjectModal from "@/components/ProjectModal";
+import useProjectModal from "@/store";
+import { Project } from "@/types/project";
+
+const ProjectsView = ({ projects }: Project) => {
+  const { project, isOpen, onClose } = useProjectModal();
+
+  return (
+    <>
+      <ProjectList projects={projects} />
+      <ProjectModal project={project} isOpen={isOpen} onClose={onClose} />
+    </>
+  );
+};
+
+export default ProjectsView;

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+import { ProjectModalProps } from "@/types/project";
+
+const useProjectModal = create<ProjectModalProps>()(
+  devtools(
+    persist(
+      (set) => ({
+        project: null,
+        isOpen: false,
+        onOpen: (project) => set({ project, isOpen: true }),
+        onClose: () => set({ project: null, isOpen: false }),
+      }),
+      { name: "project-modal-store" }
+    )
+  )
+);
+
+export default useProjectModal;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -33,7 +33,8 @@ export type ProfileData = {
 };
 
 export type ProjectModalProps = {
-  project: Project;
+  project: Project | null;
   isOpen: boolean;
+  onOpen: (project: Project) => void;
   onClose: () => void;
 };


### PR DESCRIPTION
[add] 프로젝트 소개 페이지 구현 완료

- 개인 프로젝트 목록을 렌더링하는 /project 페이지 구현
- 프로젝트 카드에 이미지, 설명, 기간, 기술 스택, GitHub 표시
- tailwind 기반 반응형 UI 구성
- 향후 확장 가능하도록 프로젝트 데이터 구조 정리 (techStack, media 등 포함 가능성 고려)